### PR TITLE
Replace automated GitHub Actions with lefthook local gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,7 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   ci:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,7 @@
 name: Lint
 
 on:
-  push:
-    branches:
-      - '**'
-      - '!main'
+  workflow_dispatch:
 
 jobs:
   shellcheck:

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,17 @@ precommit-check: ## Run pre-commit hooks (always succeeds, for review)
 	@echo "$(YELLOW)Running all pre-commit hooks...$(NC)"
 	@pre-commit run --all-files || true
 
+.PHONY: hooks
+hooks: ## Install lefthook-managed repo hooks
+	@if ! command -v lefthook >/dev/null 2>&1; then \
+		echo "lefthook not found in PATH." >&2; \
+		echo "Install lefthook 2.1.9 or add ~/.local/share/mise/shims to PATH." >&2; \
+		exit 1; \
+	fi
+	@lefthook install
+	@echo "Installed lefthook hooks from lefthook.yml"
+	@echo "Skip one git command with: LEFTHOOK=0 git <command> or --no-verify"
+
 .PHONY: precommit-install
 precommit-install: ## Install pre-commit hooks
 	@echo "$(YELLOW)Installing pre-commit hooks...$(NC)"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,36 @@ sudo ./laemp.sh -c -p 8.4 -w nginx -d pgsql -m 5021 -S -M -r
 sudo ./laemp.sh -c -p 8.4 -w nginx -d mariadb -m 5021 --mkcert
 ```
 
+## Local Validation Hooks
+
+This repo uses lefthook for local validation before commits and pushes.
+
+```bash
+lefthook install
+# or, if you prefer the repo Makefile entrypoint:
+make hooks
+```
+
+Pre-commit checks run fast staged-file validation such as ShellCheck for shell
+scripts and YAML linting for YAML files. Pre-push runs the local CI gate from
+`lefthook.yml`.
+
+Skip a hook only when you have a specific reason:
+
+```bash
+LEFTHOOK=0 git commit ...
+LEFTHOOK=0 git push
+git commit --no-verify
+git push --no-verify
+```
+
+GitHub Actions CI is now on demand rather than automatic:
+
+```bash
+gh workflow run ci.yml
+gh workflow run lint.yml
+```
+
 ## Test Strategy
 
 ### 1. Fast host-side checks

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,14 @@
+pre-commit:
+  parallel: true
+  commands:
+    shellcheck:
+      glob: "*.sh"
+      run: scripts/hooks/check-staged-shell.sh --execute {staged_files}
+    yamllint:
+      glob: "*.{yaml,yml}"
+      run: scripts/hooks/check-staged-yaml.sh --execute {staged_files}
+
+pre-push:
+  commands:
+    local-ci:
+      run: scripts/hooks/run-local-ci.sh --execute

--- a/scripts/hooks/check-staged-shell.sh
+++ b/scripts/hooks/check-staged-shell.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/hooks/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+hook_parse_execute_flag "$@"
+set -- "${HOOK_ARGS[@]}"
+
+if hook_skip_requested; then
+  hook_print_skip_and_exit
+fi
+
+shell_files=()
+for file in "$@"; do
+  case "${file}" in
+    *.sh)
+      shell_files+=("${file}")
+      ;;
+  esac
+done
+
+if [[ "${#shell_files[@]}" -eq 0 ]]; then
+  hook_ok "shellcheck: no staged shell files"
+  exit 0
+fi
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+  hook_fail "shellcheck not found in PATH; install shellcheck or unstage shell files"
+  exit 1
+fi
+
+failed=0
+cd "${HOOKS_REPO_ROOT}"
+for file in "${shell_files[@]}"; do
+  if ! shellcheck -x "${file}"; then
+    hook_fail "${file}: fix shellcheck findings before committing"
+    failed=1
+  fi
+done
+
+if [[ "${failed}" -eq 0 ]]; then
+  hook_ok "shellcheck: ${#shell_files[@]} staged shell file(s)"
+fi
+
+exit "${failed}"

--- a/scripts/hooks/check-staged-yaml.sh
+++ b/scripts/hooks/check-staged-yaml.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/hooks/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+hook_parse_execute_flag "$@"
+set -- "${HOOK_ARGS[@]}"
+
+if hook_skip_requested; then
+  hook_print_skip_and_exit
+fi
+
+yaml_files=()
+for file in "$@"; do
+  case "${file}" in
+    *.yaml|*.yml)
+      yaml_files+=("${file}")
+      ;;
+  esac
+done
+
+if [[ "${#yaml_files[@]}" -eq 0 ]]; then
+  hook_ok "yamllint: no staged YAML files"
+  exit 0
+fi
+
+if ! command -v yamllint >/dev/null 2>&1; then
+  hook_warn "yamllint not found in PATH; skipping staged YAML lint"
+  exit 0
+fi
+
+failed=0
+cd "${HOOKS_REPO_ROOT}"
+for file in "${yaml_files[@]}"; do
+  if ! yamllint -d relaxed "${file}"; then
+    hook_fail "${file}: fix yamllint findings before committing"
+    failed=1
+  fi
+done
+
+if [[ "${failed}" -eq 0 ]]; then
+  hook_ok "yamllint: ${#yaml_files[@]} staged YAML file(s)"
+fi
+
+exit "${failed}"

--- a/scripts/hooks/lib.sh
+++ b/scripts/hooks/lib.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC2034 # Sourced hook scripts consume this shared root.
+HOOKS_REPO_ROOT="$(cd "${HOOKS_DIR}/../.." && pwd)"
+
+hook_skip_requested() {
+  [[ "${AMP_MOODLE_SKIP_HOOKS:-}" == "1" ]]
+}
+
+hook_print_skip_and_exit() {
+  echo "WARN AMP_MOODLE_SKIP_HOOKS=1; skipping ${0##*/}"
+  exit 0
+}
+
+hook_ok() {
+  echo "OK   $*"
+}
+
+hook_warn() {
+  echo "WARN $*"
+}
+
+hook_fail() {
+  echo "FAIL $*" >&2
+}
+
+hook_parse_execute_flag() {
+  if [[ "${1:-}" == "--execute" ]]; then
+    shift
+  elif [[ "${1:-}" == "--dry-run" ]]; then
+    hook_warn "dry run: ${0##*/} $*"
+    exit 0
+  fi
+
+  # shellcheck disable=SC2034 # Callers consume this array after parsing.
+  HOOK_ARGS=("$@")
+}

--- a/scripts/hooks/run-local-ci.sh
+++ b/scripts/hooks/run-local-ci.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/hooks/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+hook_parse_execute_flag "$@"
+
+if hook_skip_requested; then
+  hook_print_skip_and_exit
+fi
+
+if [[ "${AMP_MOODLE_LOCAL_CI_IN_PROGRESS:-}" == "1" ]]; then
+  hook_warn "AMP_MOODLE_LOCAL_CI_IN_PROGRESS=1; skipping run-local-ci.sh to avoid recursive local CI"
+  exit 0
+fi
+
+cd "${HOOKS_REPO_ROOT}"
+
+cat <<'EOF'
+amp-moodle pre-push local CI gate
+
+Running:
+  shellcheck -x on tracked shell scripts
+  make test-smoke-bats
+  make test-cli-bats
+
+Skip only when you have a reason:
+  LEFTHOOK=0 git push
+  AMP_MOODLE_SKIP_HOOKS=1 git push
+  git push --no-verify
+EOF
+
+export AMP_MOODLE_LOCAL_CI_IN_PROGRESS=1
+failed_gate=""
+shell_files=()
+
+while IFS= read -r file; do
+  shell_files+=("${file}")
+done < <(git ls-files '*.sh')
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+  failed_gate="shellcheck not found"
+elif ! shellcheck -x "${shell_files[@]}"; then
+  failed_gate="shellcheck -x on tracked shell scripts"
+elif ! make test-smoke-bats; then
+  failed_gate="make test-smoke-bats"
+elif ! make test-cli-bats; then
+  failed_gate="make test-cli-bats"
+fi
+
+if [[ -n "${failed_gate}" ]]; then
+  hook_fail "pre-push gate failed: ${failed_gate}"
+  exit 1
+fi
+
+hook_ok "pre-push gate passed"


### PR DESCRIPTION
## What changed

- `.github/workflows/ci.yml`: changed from automatic `push` on `main` to `workflow_dispatch` only. The existing `Run laemp.sh` job is preserved for on-demand Linux confirmation with `gh workflow run ci.yml`.
- `.github/workflows/lint.yml`: changed from automatic branch pushes to `workflow_dispatch` only. The existing ShellCheck job is preserved for on-demand confirmation with `gh workflow run lint.yml`.
- Added `lefthook.yml` plus `scripts/hooks/` local hook scripts:
  - pre-commit runs staged ShellCheck for `*.sh` files and relaxed `yamllint` for YAML files.
  - pre-push runs the local CI gate: ShellCheck on tracked shell scripts, `make test-smoke-bats`, and `make test-cli-bats`.
- Added `make hooks` as a local wrapper around `lefthook install`.
- Documented hook installation, skip mechanisms, and manual GitHub workflow runs in `README.md`.

## Local checks

Install hooks:

```bash
lefthook install
# or
make hooks
```

Run the hook scripts directly:

```bash
scripts/hooks/check-staged-shell.sh --execute laemp.sh setup-security.sh
scripts/hooks/check-staged-yaml.sh --execute .github/workflows/ci.yml .github/workflows/lint.yml lefthook.yml
scripts/hooks/run-local-ci.sh --execute
```

Verified in this staging clone:

- `scripts/hooks/check-staged-shell.sh --execute scripts/hooks/lib.sh scripts/hooks/check-staged-shell.sh scripts/hooks/check-staged-yaml.sh scripts/hooks/run-local-ci.sh`
- `scripts/hooks/check-staged-yaml.sh --execute .github/workflows/ci.yml .github/workflows/lint.yml lefthook.yml`
- `scripts/hooks/run-local-ci.sh --execute`

The full Ubuntu `laemp.sh` install job from `ci.yml` remains available on demand; it is not run automatically on local pushes because it mutates a Linux host.

Skip only when needed:

```bash
LEFTHOOK=0 git commit ...
LEFTHOOK=0 git push
git commit --no-verify
git push --no-verify
```

## Left alone

- No release or deployment workflows were present, so nothing needed to keep automatic triggers.
- `PR_BODY.md` is intentionally uncommitted and should not be staged.
